### PR TITLE
Update Ice&Fire page with Corrupted Chorus Fruit

### DIFF
--- a/gg/ice-and-fire.html
+++ b/gg/ice-and-fire.html
@@ -42,6 +42,8 @@ blurb: Ice & Fire is heavily modified in ATM 1.16 based modpacks.
       <p>Natures compass and spectral eye amulet will help. There is also a scrying ritual from Ars Nouveau that can
         locate
         chests.</p>
+      <p> In addition, Corrupted Chorus Fruit can be used to 'noclip' through blocks, allowing you to move quickly through them and see where you're going. 
+      </p>
       <p>Higher tier dragons are in underground roosts around y35.</p>
     </div>
     <div class="card-body">


### PR DESCRIPTION
Chorus fruit noclips players through terrain, making dragon searching much easier. Credit for the tip goes to "[IKON]Garnish#8112" on the ATM Discord.