### PR TITLE
Update alltheteam.md

### DIFF
--- a/docs/about/alltheteam.md
+++ b/docs/about/alltheteam.md
@@ -15,12 +15,13 @@ description: ATM Team Members!
 
 ---
 
-#### Admins
+#### All The Devs
 
 - `oly2o6`
 - `Mitchell52`
 - `MutantGumdrop`
 - `thevortex`
+- `Uncandango`
 
 ---
 
@@ -38,7 +39,6 @@ description: ATM Team Members!
 - `Satherov`
 - `Toblerone0508`
 - `ToshibaMicrowave`
-- `Uncandango`
 - `ZephyrWindSpirit`
 
 ---

--- a/docs/about/alltheteam.md
+++ b/docs/about/alltheteam.md
@@ -17,7 +17,7 @@ description: ATM Team Members!
 
 #### Admins
 
-- `oly2o6` (**Second In Command**)
+- `oly2o6`
 - `Mitchell52`
 - `MutantGumdrop`
 - `thevortex`
@@ -33,7 +33,6 @@ description: ATM Team Members!
 - `Drack.ion`
 - `Jebraltar`
 - `LobsterJonn`
-- `Nyxane`
 - `pr0saic`
 - `radiomike12`
 - `Satherov`
@@ -57,11 +56,11 @@ description: ATM Team Members!
 
 ---
 
-#### Former - Retired
+#### Former Team
 
 - `0mega420`
 - `Alekthefirst`
-- `AlfredGG` | **(Former QuestDev)**
+- `AlfredGG`
 - `BeeJnugggets`
 - `Billy`
 - `Dijkstra`
@@ -70,13 +69,14 @@ description: ATM Team Members!
 - `KJM`
 - `KyBeeS`
 - `Maddy`
+- `Nyxane`
 - `Phantom`
 - `screret`
 - `Seg`
 - `Thunder_Nova the Pun_isher`
 - `uʍopǝpᴉsdn`
 - `Yumi`
-- `wva`
+- `micrwvae`
 
 ---
 

--- a/docs/about/alltheteam.md
+++ b/docs/about/alltheteam.md
@@ -21,7 +21,6 @@ description: ATM Team Members!
 - `Mitchell52`
 - `MutantGumdrop`
 - `thevortex`
-- `Ki-Tan`
 
 ---
 
@@ -32,6 +31,7 @@ description: ATM Team Members!
 - `DJNifos`
 - `Drack.ion`
 - `Jebraltar`
+- `Ki-Tan`
 - `LobsterJonn`
 - `pr0saic`
 - `radiomike12`
@@ -80,4 +80,4 @@ description: ATM Team Members!
 
 ---
 
-> Current as of (03/24/2025)
+> Current as of (08/16/2025)


### PR DESCRIPTION
- Moved Nyxane from Modpack Team to Former Team
- Removed text in brackets after oly2o6 and AlfredGG as I don't believe it's needed
- Changed wva's name to match their name on Discord
- Changed the 'Former - Retired' category to 'Former Team'
- Changed the ‘Admins’ category to ‘All The Devs’
- Moved Ki-tan from All The Devs to Modpack Team
- Moved Uncandango from Modpack Team to All The Devs